### PR TITLE
Add configurable feed length

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ These env vars are available however you run orkid-ui.
 
 > Redis port to connect to. Default 6379.
 
+**REACT_APP_FEED_LENGTH**
+
+> Number of items to show per page in task feed. Default 10.
+
 ---
 
 ## Development

--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,3 @@
-const feedLength = 10;
+const feedLength = Number(process.env.REACT_APP_FEED_LENGTH || 10);
+
 export { feedLength };


### PR DESCRIPTION
Reason for `REACT_APP_` prefix: https://create-react-app.dev/docs/adding-custom-environment-variables#adding-development-environment-variables-in-env